### PR TITLE
Validated "required.method.not.called" warning suppressions

### DIFF
--- a/zookeeper-server/pom.xml
+++ b/zookeeper-server/pom.xml
@@ -163,56 +163,32 @@
     </dependency>
 
     <dependency>
-      <groupId>org.checkerframework</groupId>
-      <artifactId>checker-qual</artifactId>
-      <!--      <version>0.5.1</version>-->
-      <version>3.12.0</version>
-      <!--      <scope>system</scope>-->
-      <!--      <systemPath>${env.CHECKERFRAMEWORK}/checker/dist/jdk8.jar</systemPath>-->
-    </dependency>
-    <dependency>
-      <groupId>com.google.errorprone</groupId>
-      <artifactId>javac</artifactId>
-      <version>9+181-r4173-1</version>
-    </dependency>
-
-    <dependency>
-      <groupId>net.sridharan.objectconstruction</groupId>
-      <artifactId>object-construction-qual</artifactId>
-      <version>0.1.12</version>
-    </dependency>
-    <dependency>
-      <groupId>net.sridharan.objectconstruction</groupId>
-      <artifactId>must-call-qual</artifactId>
-      <version>0.1.12</version>
-    </dependency>
-    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.zookeeper</groupId>
-      <artifactId>zookeeper</artifactId>
-      <version>3.4.13</version>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.zookeeper</groupId>
-      <artifactId>zookeeper</artifactId>
-      <version>3.7.0-SNAPSHOT</version>
-      <scope>compile</scope>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.zookeeper</groupId>
-      <artifactId>zookeeper</artifactId>
-      <version>3.4.13</version>
+      <groupId>org.junit.platform</groupId>
+      <artifactId>junit-platform-runner</artifactId>
+      <scope>test</scope>
     </dependency>
+
     <dependency>
       <groupId>aopalliance</groupId>
       <artifactId>aopalliance</artifactId>
       <version>1.0</version>
     </dependency>
+
     <dependency>
       <groupId>org.checkerframework</groupId>
       <artifactId>checker-qual</artifactId>
@@ -234,6 +210,7 @@
       <artifactId>must-call-qual</artifactId>
       <version>0.1.12</version>
     </dependency>
+
   </dependencies>
 
   <properties>
@@ -302,7 +279,6 @@
         </executions>
       </plugin>
       <plugin>
-        <!-- This plugin will set properties values using dependency information -->
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
         <executions>
@@ -377,7 +353,7 @@
             <path>
               <groupId>net.sridharan.objectconstruction</groupId>
               <artifactId>object-construction-checker</artifactId>
-              <version>0.1.13-SNAPSHOT</version>
+              <version>0.1.13</version>
             </path>
             <path>
               <groupId>org.checkerframework</groupId>

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/ClientCnxnSocketNIO.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/ClientCnxnSocketNIO.java
@@ -47,7 +47,7 @@ public class ClientCnxnSocketNIO extends ClientCnxnSocket {
 
     private static final Logger LOG = LoggerFactory.getLogger(ClientCnxnSocketNIO.class);
 
-    @SuppressWarnings("objectconstruction:required.method.not.called") // FP: initializer
+    @SuppressWarnings("objectconstruction:required.method.not.called") // FP: initializing @Owning field (validated)
     private final @Owning Selector selector = Selector.open();
 
     private SelectionKey sockKey;
@@ -309,7 +309,7 @@ public class ClientCnxnSocketNIO extends ClientCnxnSocket {
         return localSocketAddress;
     }
 
-    @SuppressWarnings("objectconstruction:required.method.not.called") // FP: MCC with field
+    @SuppressWarnings("objectconstruction:required.method.not.called") // FP: socket is a resource alias of the owning field selector, so it doesn't need to be closed (validated)
     private void updateSocketAddresses() {
         Socket socket = ((SocketChannel) sockKey.channel()).socket();
         localSocketAddress = socket.getLocalSocketAddress();
@@ -326,7 +326,7 @@ public class ClientCnxnSocketNIO extends ClientCnxnSocket {
         wakeupCnxn();
     }
 
-    @SuppressWarnings("objectconstruction:required.method.not.called") // FP: MCC with owning field
+    @SuppressWarnings("objectconstruction:required.method.not.called") // FP: java.nio.channels.Selector#wakeup needs @MustCallAlias on its receiver and return value (validated)
     private synchronized void wakeupCnxn() {
         selector.wakeup();
     }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/client/FourLetterWordMain.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/client/FourLetterWordMain.java
@@ -84,7 +84,7 @@ public class FourLetterWordMain {
      * @throws java.io.IOException
      * @throws SSLContextException
      */
-    @SuppressWarnings("objectconstruction:required.method.not.called") // TP: setSoTimeout called on sock after it is already connected.
+    @SuppressWarnings("objectconstruction:required.method.not.called") // TP: setSoTimeout (called on sock after it is already connected) could throw an exception and then sock would not be closed (validated)
     public static String send4LetterWord(
         String host,
         int port,

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/common/FileChangeWatcher.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/common/FileChangeWatcher.java
@@ -65,7 +65,7 @@ public final class FileChangeWatcher {
      *                 and <code>event.context()</code> will return the filename relative to <code>dirPath</code>.
      * @throws IOException if there is an error creating the WatchService.
      */
-    @SuppressWarnings("objectconstruction:required.method.not.called") // FP: I'm not familiar with these APIs, but as far as I can tell they don't actually need to be closed?
+    @SuppressWarnings("objectconstruction:required.method.not.called") // FP: FileSystem and WatchService need not be closed. (validated)
     public FileChangeWatcher(Path dirPath, Consumer<WatchEvent<?>> callback) throws IOException {
         FileSystem fs = dirPath.getFileSystem();
         WatchService watchService = fs.newWatchService();

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/NIOServerCnxnFactory.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/NIOServerCnxnFactory.java
@@ -632,9 +632,8 @@ public class NIOServerCnxnFactory extends ServerCnxnFactory {
 
     @Override
     @SuppressWarnings({
-            "objectconstruction:required.method.not.called", // FP: at "this.ss = ...", but `ss` is an `@Owning` field, so there should be no error. (Note that there is a mysterious error at the declaration of `ss`.)
-            "objectconstruction:reset.not.owning" // TODO
- // FP: even though ss is bound before the call to configureBlocking, which could throw an exception, this method rethrows that exception, where it can be caught by the caller. That caller is then responsible for closing ss, which has already been assigned into its field - so no reference to it is lost.
+            "objectconstruction:required.method.not.called", // FP: assignment to @Owning field.  ss is bound before configureBlocking, which can throw an exception, is called. If configureBlocking does throw an exception, though, it is caught - so the caller of reconfigure() will still be able to safely close out this, as they should. (validated)
+            "objectconstruction:reset.not.owning" // FP: calls to bind() on ss.socket() require the @CreatesObligation("this") annotation (because ss is an owning field), but the checker doesn't use the fact that ss.socket() is a resource alias of ss and so issues this error
     })
     @CreatesObligation("this")
     public void configure(InetSocketAddress addr, int maxcc, int backlog, boolean secure) throws IOException {

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/SnapshotComparer.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/SnapshotComparer.java
@@ -258,7 +258,7 @@ public class SnapshotComparer {
    * @param file the snapshot file
    * @throws Exception
    */
-  @SuppressWarnings("objectconstruction:required.method.not.called") // TP: snapIS has a file descriptor, and is never closed.
+  @SuppressWarnings("objectconstruction:required.method.not.called") // TP: snapIS has a file descriptor, and is never closed. (validated)
   private static DataTree getSnapshot(File file) throws Exception {
     FileSnap fileSnap = new FileSnap(null);
     DataTree dataTree = new DataTree();

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/TraceFormatter.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/TraceFormatter.java
@@ -33,7 +33,7 @@ public class TraceFormatter {
      * @param args
      * @throws IOException
      */
-    @SuppressWarnings("objectconstruction:required.method.not.called") // TP: fc is never closed; seems to rely on program exit to be freed
+    @SuppressWarnings("objectconstruction:required.method.not.called") // TP: fc is never closed; seems to rely on program exit to be freed (validated)
     public static void main(String[] args) throws IOException {
         if (args.length != 1) {
             System.err.println("USAGE: TraceFormatter trace_file");

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/persistence/FileTxnLog.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/persistence/FileTxnLog.java
@@ -236,7 +236,7 @@ public class FileTxnLog implements TxnLog, Closeable {
      * rollover the current log file to a new one.
      * @throws IOException
      */
-    @SuppressWarnings({"objectconstruction:required.method.not.called", "objectconstruction:missing.reset.mustcall"}) // TP: see below
+    @SuppressWarnings({"objectconstruction:required.method.not.called", "objectconstruction:missing.reset.mustcall"}) // TP: see below (validated)
     public synchronized void rollLog() throws IOException {
         if (logStream != null) {
             this.logStream.flush();
@@ -275,7 +275,7 @@ public class FileTxnLog implements TxnLog, Closeable {
 
     @Override
     @CreatesObligation("this")
-    @SuppressWarnings("objectconstruction:required.method.not.called") // for the required.method.not.called error, see comment below. This warning suppresses the related warnings.
+    @SuppressWarnings("objectconstruction:required.method.not.called") // TP: for the required.method.not.called error, see comment below. This warning suppresses the related warnings. (validated)
     public synchronized boolean append(TxnHeader hdr, Record txn, TxnDigest digest) throws IOException {
         if (hdr == null) {
             return false;
@@ -399,7 +399,7 @@ public class FileTxnLog implements TxnLog, Closeable {
      * commit the logs. make sure that everything hits the
      * disk
      */
-    @SuppressWarnings("objectconstruction:required.method.not.called") // FP: requires container support for list of owners
+    @SuppressWarnings("objectconstruction:required.method.not.called") // FP: requires container support for list of owners (validated)
     public synchronized void commit() throws IOException {
         if (logStream != null) {
             logStream.flush();
@@ -492,7 +492,7 @@ public class FileTxnLog implements TxnLog, Closeable {
             }
             long pos = input.getPosition();
             // now, truncate at the current position
-            @SuppressWarnings("objectconstruction:required.method.not.called") // TP: setLength can throw, which would cause raf not to be closed.
+            @SuppressWarnings("objectconstruction:required.method.not.called") // TP: setLength can throw, which would cause raf not to be closed. (validated)
             RandomAccessFile raf = new RandomAccessFile(itr.logFile, "rw");
             raf.setLength(pos);
             raf.close();

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/persistence/SnapStream.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/persistence/SnapStream.java
@@ -99,7 +99,7 @@ public class SnapStream {
      * @return the specific InputStream
      * @throws IOException
      */
-    @SuppressWarnings("objectconstruction:required.method.not.called") // TP: GZIPInputStream constructor can throw format exceptions, which would cause fis to leak.
+    @SuppressWarnings("objectconstruction:required.method.not.called") // TP: GZIPInputStream constructor can throw format exceptions, which would cause fis to leak. (validated)
     public static CheckedInputStream getInputStream(File file) throws IOException {
         FileInputStream fis = new FileInputStream(file);
         InputStream is;
@@ -125,7 +125,7 @@ public class SnapStream {
      * @return the specific OutputStream
      * @throws IOException
      */
-    @SuppressWarnings("objectconstruction:required.method.not.called") // TP: fos can leak if the GZIPOutputStream constructor throws an exception, which it can: see the discussion of https://bugs.openjdk.java.net/browse/JDK-8180899, which complains about it.
+    @SuppressWarnings("objectconstruction:required.method.not.called") // TP: fos can leak if the GZIPOutputStream constructor throws an exception, which it can: see the discussion of https://bugs.openjdk.java.net/browse/JDK-8180899, which complains about it. (validated)
     public static CheckedOutputStream getOutputStream(File file, boolean fsync) throws IOException {
         OutputStream fos = fsync ? new AtomicFileOutputStream(file) : new FileOutputStream(file);
         OutputStream os;

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/persistence/TxnLogToolkit.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/persistence/TxnLogToolkit.java
@@ -360,7 +360,7 @@ public class TxnLogToolkit implements Closeable {
         return new String(data, StandardCharsets.UTF_8);
     }
 
-    @SuppressWarnings("objectconstruction:required.method.not.called") // FP: for "txnFis = ...": this method is called only from the constructor and is the only assignment to txnFis.
+    @SuppressWarnings("objectconstruction:required.method.not.called") // FP: for "txnFis = ...": this method is called only from the constructor and is the only assignment to txnFis. (validated)
     private void openTxnLogFile() throws FileNotFoundException {
         txnFis = new FileInputStream(txnLogFile);
         logStream = BinaryInputArchive.getArchive(txnFis);
@@ -372,7 +372,7 @@ public class TxnLogToolkit implements Closeable {
         }
     }
 
-    @SuppressWarnings("objectconstruction:required.method.not.called") // FP: for "recoveryFos = ...": this method is called only from the constructor and is the only assignment to recoveryFos.
+    @SuppressWarnings("objectconstruction:required.method.not.called") // FP: for "recoveryFos = ...": this method is called only from the constructor and is the only assignment to recoveryFos. (validated)
     private void openRecoveryFile() throws FileNotFoundException {
         recoveryFos = new FileOutputStream(recoveryLogFile);
         recoveryOa = BinaryOutputArchive.getArchive(recoveryFos);

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/persistence/TxnLogToolkit.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/persistence/TxnLogToolkit.java
@@ -99,12 +99,14 @@ public class TxnLogToolkit implements Closeable {
     private File txnLogFile;
     private boolean recoveryMode = false;
     private boolean verbose = false;
-    private FileInputStream txnFis;
+    @SuppressWarnings("objectconstruction:required.method.not.called") // FP: checker bug: declared @Owning field
+    private @Owning FileInputStream txnFis;
     private BinaryInputArchive logStream;
 
     // Recovery mode
     private int crcFixed = 0;
-    private FileOutputStream recoveryFos;
+    @SuppressWarnings("objectconstruction:required.method.not.called") // FP: checker bug: declared @Owning field
+    private @Owning FileOutputStream recoveryFos;
     private BinaryOutputArchive recoveryOa;
     private File recoveryLogFile;
     private FilePadding filePadding = new FilePadding();
@@ -361,6 +363,7 @@ public class TxnLogToolkit implements Closeable {
         return new String(data, StandardCharsets.UTF_8);
     }
 
+    @SuppressWarnings("objectconstruction:required.method.not.called") // FP: for "txnFis = ...": this method is called only from the constructor and is the only assignment to txnFis.
     private void openTxnLogFile() throws FileNotFoundException {
         txnFis = new FileInputStream(txnLogFile);
         logStream = BinaryInputArchive.getArchive(txnFis);
@@ -372,6 +375,7 @@ public class TxnLogToolkit implements Closeable {
         }
     }
 
+    @SuppressWarnings("objectconstruction:required.method.not.called") // FP: for "recoveryFos = ...": this method is called only from the constructor and is the only assignment to recoveryFos.
     private void openRecoveryFile() throws FileNotFoundException {
         recoveryFos = new FileOutputStream(recoveryLogFile);
         recoveryOa = BinaryOutputArchive.getArchive(recoveryFos);

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/persistence/TxnLogToolkit.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/persistence/TxnLogToolkit.java
@@ -61,7 +61,6 @@ import org.apache.zookeeper.txn.Txn;
 import org.apache.zookeeper.txn.TxnHeader;
 import org.apache.zookeeper.util.ServiceUtils;
 
-@SuppressWarnings("objectconstruction:required.method.not.called") // FP: The logic here is confusing. There are two variables that are set early that control whether these files get opened and closed: recovery mode and txn log mode. These variables are either always null, or if they're nonnull then the class has extra methods that have to be called. I think it's very errorprone, but it could be correct; we certainly cannot verify this kind of control flow, though, and I don't think that's a bad thing.
 public class TxnLogToolkit implements Closeable {
 
     static class TxnLogToolkitException extends Exception {
@@ -99,14 +98,12 @@ public class TxnLogToolkit implements Closeable {
     private File txnLogFile;
     private boolean recoveryMode = false;
     private boolean verbose = false;
-    @SuppressWarnings("objectconstruction:required.method.not.called") // FP: checker bug: declared @Owning field
-    private @Owning FileInputStream txnFis;
+    private FileInputStream txnFis;
     private BinaryInputArchive logStream;
 
     // Recovery mode
     private int crcFixed = 0;
-    @SuppressWarnings("objectconstruction:required.method.not.called") // FP: checker bug: declared @Owning field
-    private @Owning FileOutputStream recoveryFos;
+    private FileOutputStream recoveryFos;
     private BinaryOutputArchive recoveryOa;
     private File recoveryLogFile;
     private FilePadding filePadding = new FilePadding();

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/Leader.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/Leader.java
@@ -305,7 +305,7 @@ public class Leader extends LearnerMaster {
         this.zk = zk;
     }
 
-    @SuppressWarnings("objectconstruction:required.method.not.called") // FP: we need to support generic containers such as Optional taking ownership
+    @SuppressWarnings("objectconstruction:required.method.not.called") // FP: we need to support generic containers such as Optional taking ownership (validated)
     Optional<ServerSocket> createServerSocket(InetSocketAddress address, boolean portUnification, boolean sslQuorum) {
         ServerSocket serverSocket;
         try {
@@ -506,7 +506,7 @@ public class Leader extends LearnerMaster {
                 }
             }
 
-            @SuppressWarnings("objectconstruction:required.method.not.called") // FP: call to close is controlled by the error boolean. Validated by hand.
+            @SuppressWarnings("objectconstruction:required.method.not.called") // FP: call to close is controlled by the error boolean. Validated by hand. (validated)
             private void acceptConnections() throws IOException {
                 Socket socket = null;
                 boolean error = false;
@@ -826,7 +826,7 @@ public class Leader extends LearnerMaster {
         isShutdown = true;
     }
 
-    @SuppressWarnings("objectconstruction:required.method.not.called") // FP: need support for owning lists
+    @SuppressWarnings("objectconstruction:required.method.not.called") // FP: need support for owning lists (validated)
     synchronized void closeSockets() {
        for (ServerSocket serverSocket : serverSockets) {
            if (!serverSocket.isClosed()) {

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/Learner.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/Learner.java
@@ -318,7 +318,7 @@ public class Learner {
      * if there is an authentication failure while connecting to leader
      */
     @CreatesObligation("this")
-    @SuppressWarnings("objectconstruction:required.method.not.called") // FP: this applies to the assignments at the end of the method to leaderIs etc. These are all MCC with the `sock` field, which is owning, so it doesn't matter if they aren't closed.
+    @SuppressWarnings("objectconstruction:required.method.not.called") // TP: see the comment on the assignment sock = socketGet below (validated)
     protected void connectToLeader(MultipleAddresses multiAddr, String hostname) throws IOException {
 
         this.leaderAddr = multiAddr;
@@ -383,7 +383,7 @@ public class Learner {
         }
 
         @Override
-        @SuppressWarnings("objectconstruction:required.method.not.called") // FP: sock is either assigned into the container AtomicReference, which becomes the owner, or is closed. Needs support for generic containers.
+        @SuppressWarnings("objectconstruction:required.method.not.called") // FP: sock is either assigned into the AtomicReference `socket`, which becomes the owner, or is closed. Needs support for generic containers. (validated)
         public void run() {
             try {
                 Thread.currentThread().setName("LeaderConnector-" + address);
@@ -405,7 +405,7 @@ public class Learner {
             }
         }
 
-        @SuppressWarnings("objectconstruction:required.method.not.called") // TP: see below
+        @SuppressWarnings("objectconstruction:required.method.not.called") // TP: see below (validated)
         private Socket connectToLeader() throws IOException, X509Exception, InterruptedException {
             Socket sock = createSocket();
 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/ObserverMaster.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/ObserverMaster.java
@@ -429,7 +429,7 @@ public class ObserverMaster extends LearnerMaster implements Runnable {
         sendPacket(informAndActivateQP);
     }
 
-    @SuppressWarnings("objectconstruction:required.method.not.called") // FP there is implicitly a check that ss is null before the assignments: `thread` is checked for null, and if it isn't null then this routine returns early, and only this routine assigns both the socket and thread.
+    @SuppressWarnings("objectconstruction:required.method.not.called") // FP: warning about overwriting `ss`.  After the first if statement, thread is null, or thread is non-null and not alive. If thread is null, this is the first time that start() has been called, and ss is being set for the first time.  If thread is non-null and not alive, then stop() has been called (this code does not use the more modern interrupt() idiom), so `ss` has been closed. (validated)
     @CreatesObligation("this")
     public synchronized void start() throws IOException {
         if (thread != null && thread.isAlive()) {
@@ -458,7 +458,7 @@ public class ObserverMaster extends LearnerMaster implements Runnable {
         pinger.scheduleAtFixedRate(ping, self.tickTime / 2, self.tickTime / 2, TimeUnit.MILLISECONDS);
     }
 
-    @SuppressWarnings("objectconstruction:required.method.not.called") // TP: see below
+    @SuppressWarnings("objectconstruction:required.method.not.called") // TP: see below (validated)
     public void run() {
         ServerSocket ss;
         synchronized (this) {

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumCnxManager.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumCnxManager.java
@@ -374,7 +374,7 @@ public class QuorumCnxManager {
      * If this server has initiated the connection, then it gives up on the
      * connection if it loses challenge. Otherwise, it keeps the connection.
      */
-    @SuppressWarnings("objectconstruction:required.method.not.called") // FP: SOCKET_FACTORY.get() is an unconnected socket, but we don't have a way to specify that given that it's a Supplier.
+    @SuppressWarnings("objectconstruction:required.method.not.called") // FP: SOCKET_FACTORY.get() is an unconnected socket, but we don't have a way to specify that given that it's a Supplier. (validated)
     public void initiateConnection(final MultipleAddresses electionAddr, final Long sid) {
         Socket sock = null;
         try {
@@ -586,7 +586,7 @@ public class QuorumCnxManager {
     private class QuorumConnectionReceiverThread extends ZooKeeperThread {
 
         private final Socket sock;
-        @SuppressWarnings("objectconstruction:required.method.not.called") // FP: this is a thread, which will definitely have run() called upon it. This method takes the socket and puts it in a field temporarily; when run is called, sock is passed to receiveConnection(), which takes ownership.
+        @SuppressWarnings("objectconstruction:required.method.not.called") // FP: this is a thread, which will definitely have run() called upon it. This method takes the socket and puts it in a field temporarily; when run is called, sock is passed to receiveConnection(), which takes ownership. (validated)
         QuorumConnectionReceiverThread(final @Owning Socket sock) {
             super("QuorumConnectionReceiverThread-" + sock.getRemoteSocketAddress());
             this.sock = sock;
@@ -599,7 +599,7 @@ public class QuorumCnxManager {
 
     }
 
-    @SuppressWarnings("objectconstruction:required.method.not.called") // TP: see below
+    @SuppressWarnings("objectconstruction:required.method.not.called") // TP: see below (validated)
     private void handleConnection(@Owning Socket sock, DataInputStream din) throws IOException {
         Long sid = null, protocolVersion = null;
         MultipleAddresses electionAddr = null;
@@ -1067,7 +1067,10 @@ public class QuorumCnxManager {
             /**
              * Sleeps on accept().
              */
-            @SuppressWarnings("objectconstruction:required.method.not.called") // FP: this method is private, and only called on new instances that don't have a nonnull ServerSocket. The loop in which serverSocket is assigned is safe, because exceptions are caught and close() is called before the loop goes around again.
+            @SuppressWarnings({
+                    "objectconstruction:required.method.not.called", // FP: Warning about re-assigning @Owning field `serverSocket`.  The first assignment is OK, because this method is private and is only called on new instances where `serverSocket` is null.  There is a second iteration only if shutdown is false.  shutdown is false only if the inner loop throws an exception, but the inner loop catches IOException and calls close() before the outer loop goes around again.  If the inner loop throws an exception other than IOException, then it is not caught by the outer loop and the outer loop terminates without iterating a second time. (validated)
+                    "objectconstruction:required.method.not.called", // TP: Warning about re-assigning local variable `client`.  The body calls receiveConnection{Async} which is owning, so that is OK.  setSockOpts may throw SocketException which is a subtype of IO exception, and the catch clause closes `client`.  However, if SocketTimeoutException is thrown, then `client` never gets closed before the next iteration of the inner while loop. (validated)
+            })
             @CreatesObligation("this")
             private void acceptConnections() {
                 int numRetries = 0;
@@ -1177,7 +1180,7 @@ public class QuorumCnxManager {
          * @param sid
          *            Server identifier of remote peer
          */
-        @SuppressWarnings({"objectconstruction:missing.reset.mustcall", "objectconstruction:required.method.not.called"}) // FP: this is a constructor, but our analysis is treating it as an instance method
+        @SuppressWarnings({"objectconstruction:missing.reset.mustcall", "objectconstruction:required.method.not.called"}) // FP: this is a constructor, but our analysis is treating it as an instance method (validated)
         SendWorker(@Owning Socket sock, Long sid) {
             super("SendWorker:" + sid);
             this.sid = sid;

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/UnifiedServerSocket.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/UnifiedServerSocket.java
@@ -198,7 +198,7 @@ public class UnifiedServerSocket extends ServerSocket {
          * @param allowInsecureConnection
          * @param prependableSocket
          */
-        @SuppressWarnings({"objectconstruction:missing.reset.mustcall","objectconstruction:required.method.not.called"}) // FP constructor treated as instance method by our analysis.
+        @SuppressWarnings({"objectconstruction:missing.reset.mustcall","objectconstruction:required.method.not.called"}) // FP constructor treated as instance method by our analysis. (validated)
         private UnifiedSocket(X509Util x509Util, boolean allowInsecureConnection, @Owning PrependableSocket prependableSocket) {
             this.x509Util = x509Util;
             this.allowInsecureConnection = allowInsecureConnection;


### PR DESCRIPTION
Martin, you will need to add "(validated)" to the end of the new `@SuppressWarnings` that I added in this pull request (e.g., in zookeeper-server/src/main/java/org/apache/zookeeper/server/persistence/TxnLogToolkit.java).