### PR TITLE
remove bad warning suppression in FileTxnLog.java, replace with COs

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/TxnLogProposalIterator.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/TxnLogProposalIterator.java
@@ -55,6 +55,7 @@ public class TxnLogProposalIterator implements Iterator<Proposal> {
      * Proposal returned by this iterator has request part set to null, since
      * it is not used for follower sync-up.
      */
+    @SuppressWarnings("objectconstruction:reset.not.owning") // TP: this method comes from java.util.Iterator, which means that it definitely cannot have an @CreatesObligation annotation - that would violate subtyping (calling next() on a variable of static type Iterator would not create a new obligation). However, the call to itr.next() actually does create a new obligation for itr. If we were checking non-JDK classes, then this class would be @MustCall("close") - note that its close method closes itr.
     @Override
     public Proposal next() {
 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/persistence/FileTxnLog.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/persistence/FileTxnLog.java
@@ -778,7 +778,7 @@ public class FileTxnLog implements TxnLog, Closeable {
          * @return true if there is more transactions to be read
          * false if not.
          */
-        @SuppressWarnings({"objectconstruction:missing.reset.mustcall", "objectconstruction:reset.not.owning"}) // FP: RMC required on assigning null
+        @CreatesObligation("this")
         public boolean next() throws IOException {
             if (ia == null) {
                 return false;

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/persistence/TxnLog.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/persistence/TxnLog.java
@@ -153,6 +153,7 @@ public interface TxnLog extends Closeable {
          * go to the next transaction record.
          * @throws IOException
          */
+        @CreatesObligation("this")
         boolean next() throws IOException;
 
         /**


### PR DESCRIPTION
I'm not sure we should actually count this TP. It's definitely a TP, but it's kinda about a class that's not in the JDK (TxnIterator, the type of `itr`) - but the call to `next()` does overwrite an owning, JDK-typed field of the class. I'm fine with either it counting as a TP or as neither.